### PR TITLE
Make MonadLogic instances compatible with logict-0.7.1.0

### DIFF
--- a/src/Control/Unification/IntVar.hs
+++ b/src/Control/Unification/IntVar.hs
@@ -140,7 +140,7 @@ instance (Monad m) => MonadState (IntBindingState t) (IntBindingT t m) where
 -- provided that logict is compiled against the same mtl/monads-fd
 -- we're getting StateT from. Otherwise we'll get a bunch of warnings
 -- here.
-instance (MonadLogic m) => MonadLogic (IntBindingT t m) where
+instance (MonadLogic m, MonadPlus m) => MonadLogic (IntBindingT t m) where
     msplit (IBT m) = IBT (coerce `liftM` msplit m)
         where
         coerce Nothing        = Nothing

--- a/src/Control/Unification/Ranked/IntVar.hs
+++ b/src/Control/Unification/Ranked/IntVar.hs
@@ -99,7 +99,7 @@ instance (Monad m) => MonadState (IntRBindingState t) (IntRBindingT t m) where
 -- provided that logict is compiled against the same mtl/monads-fd
 -- we're getting StateT from. Otherwise we'll get a bunch of warnings
 -- here.
-instance (MonadLogic m) => MonadLogic (IntRBindingT t m) where
+instance (MonadLogic m, MonadPlus m) => MonadLogic (IntRBindingT t m) where
     msplit (IRBT m) = IRBT (coerce `liftM` msplit m)
         where
         coerce Nothing        = Nothing


### PR DESCRIPTION
The latest `logict` relaxes superclasses of `MonadLogic`. Previously it required `MonadPlus` (which in its turn requires both `Monad` and `Alternative`), but now it requires `Monad` and `Alternative` directly. Nevertheless, because of `transformers` requiring `MonadPlus m` even for `Alternative (StateT t m)`, instances of `MonadLogic` for `StateT` now require an additional `MonadPlus m` constraint. Since `IntBindingT` is a newtype over `StateT`, its instances require a change as well.